### PR TITLE
Edit regex to allow Ruby-like identifiers

### DIFF
--- a/src/libsmac/src/parser.rs
+++ b/src/libsmac/src/parser.rs
@@ -4,7 +4,7 @@ use std::str::from_utf8;
 
 // Identifier
 // IDENT := /[a-zA-Z_]\w*/g
-named!(ident<&str, &str>, re_match!(r"[a-zA-Z_]\w*"));
+named!(ident<&str, &str>, re_match!(r"[a-zA-Z_]\w*[\?\!]*"));
 
 // Whitespace
 named!(whitespace, chain!(many0!(multispace), || { &b""[..] }));

--- a/src/libsmac/src/parser.rs
+++ b/src/libsmac/src/parser.rs
@@ -4,7 +4,7 @@ use std::str::from_utf8;
 
 // Identifier
 // IDENT := /[a-zA-Z_]\w*/g
-named!(ident<&str, &str>, re_match!(r"[a-zA-Z_]\w*[\?\!]*"));
+named!(ident<&str, &str>, re_match!(r"[a-zA-Z_](?:\w|[\?\!])*"));
 
 // Whitespace
 named!(whitespace, chain!(many0!(multispace), || { &b""[..] }));


### PR DESCRIPTION
Convenient for doing neater self-explaining identifier names; e.g. doing `finished?` rather than `is_finished`, along with `!` in names for things like methods that mutate the object it's called on.