### PR TITLE
fix and shorten like 2 things

### DIFF
--- a/grammar.md
+++ b/grammar.md
@@ -26,11 +26,11 @@ char_ascii         = 'a'...'z'
 identifier         = char_ascii { char_ascii | digit | '_' | '!' | '?' }
 
 (* literals *)
-literal_integer    = [ '0' ( 'x' | 'b' ) ] { digit }
+literal_integer    = [ '0' ( 'x' | 'b' ) ] digit { digit }
 literal_float      = ( { digit } '.' digit { digit } )
                    | ( '.' digit { digit } )
 literal_char       = "'" char "'"
-literal_string     = '"' [ { char } ] '"'
+literal_string     = '"' { char } '"'
 literal_raw_string = 'r' literal_string
 literal            = literal_char
                    | literal_string


### PR DESCRIPTION
according the grammer.md, "" was literal_integer. Now a literal_integer is at least 1 digit.

[] where unnecessary.