### PR TITLE
fix Float/IntLiteralMatchers so that 0b0110 and 0x0a1f work

### DIFF
--- a/src/libsmac/src/lexer/matcher.rs
+++ b/src/libsmac/src/lexer/matcher.rs
@@ -104,7 +104,7 @@ impl Matcher for FloatLiteralMatcher {
         if accum.contains('.') {
             token!(tokenizer, FloatLiteral, accum)
         } else {
-            token!(tokenizer, IntLiteral, accum)
+            None
         }
     }
 }


### PR DESCRIPTION
It is a simple fix really, anyway you're welcome :)